### PR TITLE
handle tls upgrade errors

### DIFF
--- a/lib/proxying-agent.js
+++ b/lib/proxying-agent.js
@@ -125,6 +125,19 @@ ProxyingAgent.prototype.startProxying = function(req, host, port, localAddress) 
         this.setSocket(req, tlsSocket);
         this.execRequest(req, this.options.host, this.options.port, localAddress);
       }.bind(this));
+
+      tlsSocket.once('close', function() {
+        this.emitError(req, 'Socket upgrade to tls closed closed prematurely.');
+      }.bind(this));
+
+      tlsSocket.once('error', function(error) {
+        this.emitError(req, 'Socket upgrade to tls failed. TLS upgrade error: ' + error);
+      }.bind(this));
+
+      tlsSocket.once('connect', function () {
+        // remove close event but keep error event just in case.
+        tlsSocket.removeAllListeners(['close']);
+      })
     }.bind(this));
 
     // execute the CONNECT method to create the tunnel


### PR DESCRIPTION
This was the root cause of a crashing bug in an old version node-newrelic that used this library. This appears to be the only EE that doesn't have its error handler dealt with. I'm not super keen on the `newReq.removeAllListeners()` that doesn't leave the error handler hooked up, it should probably left in tact as well.

The issue, if you wish to reproduce it, is use this to connect to an end node with a cert error (such as if the cert is invalid, expired, etc).

```
[client] -> [proxy] -> [end node]
```