### PR TITLE
Don't pass default port in absoluteURI

### DIFF
--- a/lib/proxying-agent.js
+++ b/lib/proxying-agent.js
@@ -43,6 +43,21 @@ function ProxyingAgent(options, agent) {
 }
 
 /**
+ * Get absolutURI without port when using default
+ */
+ProxyingAgent.prototype.getAbsoluteURI = function(ssl, host, port, path) {
+  var absoluteUri = (ssl ? 'https://' : 'http://') + host;
+    
+  if (port !== (ssl ? 443 : 80)) {
+    absoluteUri += ':' + port;
+  }
+    
+  absoluteUri += path;
+  
+  return absoluteUri;
+};
+
+/**
  * Overrides the 'addRequest' Agent method for establishing a socket with the proxy
  * that will e used to issue the actual request
  */
@@ -134,8 +149,7 @@ ProxyingAgent.prototype.startProxying = function(req, host, port) {
     newReq.end();
   } else {
     // issue a regular proxy request
-    var protocol = this.options.ssl ? 'https://' : 'http://';
-    req.path = protocol+host+':'+port+req.path;
+    req.path = this.getAbsoluteURI(this.options.ssl, host, port, req.path);
     if (this.authHeader) {
       req.setHeader(this.authHeader.header, this.authHeader.value);
     }
@@ -150,7 +164,7 @@ ProxyingAgent.prototype.startProxying = function(req, host, port) {
 ProxyingAgent.prototype.startNtlm = function(req, host, port) {
   var ntlmOptions = util._extend({}, this.options);
   ntlmOptions.method = ntlmOptions.method || 'GET'; // just for the NTLM handshake
-  ntlmOptions.path = (this.options.ssl ? 'https://' : 'http://')+host+':'+port+req.path
+  ntlmOptions.path = this.getAbsoluteURI(this.options.ssl, host, port, req.path);
   ntlmOptions.ntlm.workstation = ntlmOptions.ntlm.workstation || require('os').hostname();
 
   var creds = this.options.proxy.auth.split(':');

--- a/lib/proxying-agent.js
+++ b/lib/proxying-agent.js
@@ -47,13 +47,15 @@ function ProxyingAgent(options, agent) {
  */
 ProxyingAgent.prototype.getAbsoluteURI = function(ssl, host, port, path) {
   var absoluteUri = (ssl ? 'https://' : 'http://') + host;
-    
-  if (port !== (ssl ? 443 : 80)) {
+
+  if (typeof port === 'string') {
+    // Check if target url have specified port and add it to absoluteUri
+    // When port is defined in target url then we get it as a string otherwise it's a number
     absoluteUri += ':' + port;
   }
-    
+
   absoluteUri += path;
-  
+
   return absoluteUri;
 };
 


### PR DESCRIPTION
According to https://www.ietf.org/rfc/rfc2068.txt (page 35) it's not required to pass default HTTP(S) port in request URI. Some applications generate link hrefs or other URIs based on this URI and at the end we get some strange URIs like `http://google.com:80/`.

This PR skips port when using default one.

Examples:
```
# previously
GET http://google.com:80/ HTTP/1.1\r\n
# now
GET http://google.com/ HTTP/1.1\r\n

# previously
GET https://google.com:443/ HTTP/1.1\r\n
# now
GET https://google.com/ HTTP/1.1\r\n

# previously
GET https://google.com:8080/ HTTP/1.1\r\n
# now
GET https://google.com:8080/ HTTP/1.1\r\n
```